### PR TITLE
Write documentation for JSONSchema references in component metadata files

### DIFF
--- a/content/_references/component-json-metadata.md
+++ b/content/_references/component-json-metadata.md
@@ -1,6 +1,6 @@
 ---
 title: Metadata Schemas for Components
-description: This technical reference describes the schema rules for in and out metadata for components
+description: This technical reference describes how to implement JSONSchema references in .in and .out component metadata
 layout: article
 section: Component.json
 order: 7
@@ -9,34 +9,53 @@ category: component-descriptor
 
 ## JSONSchema References
 
-You can use [JSONSchema references](https://json-schema.org) in Component metadata. Basically, it allows you to avoid repetitive coding by referencing certain keys called definitions. Let's take Email Component as an example. Here you can see three address fields `To`, `Cc` and `Bcc`:
+You can use [JSONSchema references](https://json-schema.org) in Component metadata files (i.e. files with `.in.json` and `.out.json` extensions). Basically, it allows you to avoid repetitive coding by referencing certain keys called definitions. Let's take an Order component metadata file (we'll call it `order.in.json`) as an example. Here you can see that this component has two address fields `billing_address` and `shipping_address`, each with some subfields:
+
+`order.in.json`:
 
 ```json
 {
-  "actions": {
-    "send": {
-      "main": "./send.js",
-      "title": "Send Mail",
-      "metadata": {
-        "in": {
-          "type": "object",
-          "properties": {
-            "to": {
-              "title": "To",
-              "type": "string",
-              "required": true
-            },
-            "cc": {
-              "title": "Cc",
-              "type": "string",
-              "required": false
-            },
-            "bcc": {
-              "title": "Bcc",
-              "type": "string",
-              "required": false
-            }
-          }
+  "type": "object",
+  "properties": {
+    "billing_address": {
+      "type": "object",
+      "required": true,
+      "properties": {
+        "street_address": {
+          "type": "string",
+          "required": true
+        },
+        "city": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true
+        },
+        "telephone": {
+          "type": "number"
+        }
+      }
+    },
+    "shipping_address": {
+      "type": "object",
+      "required": true,
+      "properties": {
+        "street_address": {
+          "type": "string",
+          "required": true
+        },
+        "city": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true
+        },
+        "telephone": {
+          "type": "number"
         }
       }
     }
@@ -44,42 +63,30 @@ You can use [JSONSchema references](https://json-schema.org) in Component metada
 }
 ```
 
-The thing about them is that they are basically the same element. So what you can do is add a definition for address fields, and just refer to it every time you need one. Here is how it will look like:
+Note that the subfields for each address are the same. This means you can assign a more general type `addressfields` that represents both `billing_address` and `shipping_address`. You can implement this by adding a definition for `addressfields`, and just refer to the definition every time you want an object with the same shape:
 
 ```json
 {
   "definitions": {
     "addressfields": {
+      "$id": "#addressfields",
       "type": "object",
+      "required": true,
       "properties": {
-        "To":           { "type": "string" },
-        "Cc":           { "type": "string" },
-        "Bcc":          { "type": "string" }
-      },
-      "required": ["To"]
-    }
-  }
-}
-```
-
-When you need to refer to this definition from elsewhere using the `$ref` keyword:
-
-`{ "$ref": "#/definitions/addressfields" }`
-
-So if we go back to our initial Email Component, with a set reference it will look like this:
-
-```json
-{
-  "actions": {
-    "send": {
-      "main": "./send.js",
-      "title": "Send Mail",
-      "metadata": {
-        "in": {
-          "type": "object",
-          "properties": {
-            "$ref": "#/definitions/addressfields"
-          }
+        "street_address": {
+          "type": "string",
+          "required": true
+        },
+        "city": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true
+        },
+        "telephone": {
+          "type": "number"
         }
       }
     }
@@ -87,4 +94,48 @@ So if we go back to our initial Email Component, with a set reference it will lo
 }
 ```
 
->**IMPORTANT:** We do not support referencing by `$id` and referencing external schemas at the moment.
+This definition can be referred to by replacing the object definition with just the `$ref` keyword and the value of the definition's `$id` field:
+
+`{ "$ref": "#addressfields" }`
+
+Now, your `order.in.json` file will look like this:
+
+```json
+{
+  "definitions": {
+    "addressfields": {
+      "$id": "#addressfields",
+      "type": "object",
+      "required": true,
+      "properties": {
+        "street_address": {
+          "type": "string",
+          "required": true
+        },
+        "city": {
+          "type": "string",
+          "required": true
+        },
+        "state": {
+          "type": "string",
+          "required": true
+        },
+        "telephone": {
+          "type": "number"
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "billing_address": {
+      "$ref": "#addressfields"
+    },
+    "shipping_address": {
+      "$ref": "#addressfields"
+    }
+  }
+}
+```
+
+>**IMPORTANT:** We do not support referencing with paths and referencing external schemas at the moment.


### PR DESCRIPTION
The documentation didn't cover any of the real functionality for using references (`$ref`s) and definitions in component metadata. As well, the old example given didn't demonstrate the problem that the feature was trying to solve. So I rewrote the file and provide a new example.

Some issues were also uncovered in my attempts to add a `$ref` for my own component, in particular, the lack of support for path references (despite that being the only thing the documentation talked about), and the specific files where `$ref`s/definitions are supported--only .in.json and .out.json files, it seems. I'll be reporting these issues to the platform team.