### PR TITLE
Fixing broken links

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -68,6 +68,8 @@ GEM
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.12.5-x86_64-linux)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     progressbar (1.11.0)
@@ -89,6 +91,7 @@ GEM
 PLATFORMS
   x86-mingw32
   x86_64-darwin-21
+  x86_64-linux-musl
 
 DEPENDENCIES
   jekyll-algolia

--- a/content/_components/aws-s3/index.md
+++ b/content/_components/aws-s3/index.md
@@ -523,4 +523,4 @@ Click to expand - Output metadata
 ## Known Limitations
 
 1. Maximal possible size for an attachment is 10 MB.
-2. Attachments mechanism does not work with [Local Agent Installation](/getting-started/local-agent)
+2. Attachments mechanism does not work with Local Agent Installation.

--- a/content/_components/salesforce/index.md
+++ b/content/_components/salesforce/index.md
@@ -133,4 +133,4 @@ Use this list to navigate to the action you seek.
 
 ## Known limitations
 
-Attachments mechanism does not work with [Local Agent Installation](/getting-started/local-agent)
+Attachments mechanism does not work with Local Agent Installation.

--- a/content/_developers/component-json-technical-reference.md
+++ b/content/_developers/component-json-technical-reference.md
@@ -74,7 +74,7 @@ Determines how the component should be built and run on the platform
 
 ## Credentials Object
 
-This identifies the information that the platform needs to collect from the integrator in order to be able to connect to their instance/account.  Information that is collected in this section typically include:
+This identifies the information that the platform needs to collect from the integrator in order to be able to connect to their instance/account. Information that is collected in this section typically include:
 * URL to the integrator's instance (if there is not a shared cloud url)
 * Username or other account identifier
 * Password or other API keys/tokens required to authenticate
@@ -87,7 +87,7 @@ This identifies the information that the platform needs to collect from the inte
 
 The `actions` object describes the actions that exist within the component. The `triggers` object describes the triggers that exist within the component.
 
-Actions are operations exposed to the flow builder that can be placed in any step except the first step.  
+Actions are operations exposed to the flow builder that can be placed in any step except the first step.
 
 Triggers are operations exposed to the flow builder that can only be placed in the first step of a flow.
 
@@ -109,7 +109,7 @@ Used to signal that this action/trigger should not be used in new flows and that
 
 ## ConsumesRawData
 
-Normally for webhook triggers, the platform will attempt to parse incoming data to the JSON equivalent before handing it to the component code.  
+Normally for webhook triggers, the platform will attempt to parse incoming data to the JSON equivalent before handing it to the component code.
 
 When this value is set to `true`, then the HTTP body of the incoming request will be passed to your component as an unparsed string in the `msg.body.rawData` field.
 

--- a/content/_developers/error-retry.md
+++ b/content/_developers/error-retry.md
@@ -26,7 +26,7 @@ connecting and downloading the data would fail. This would disrupt your integrat
 To recover from this situation might seem tricky at first, but, the platform
 features are here to help.
 
-As a good sign we suggest using the [snapshots](/developers/snapshot-overview) to save the state of
+As a good sign we suggest using the [snapshots](/guides/using-snapshot) to save the state of
 the step. Configure the [rebound](/getting-started/rebound) to enable automatic retry
 of messages in case of failures. And the last not least, use the retry.
 

--- a/content/_developers/error-retry.md
+++ b/content/_developers/error-retry.md
@@ -26,7 +26,7 @@ connecting and downloading the data would fail. This would disrupt your integrat
 To recover from this situation might seem tricky at first, but, the platform
 features are here to help.
 
-As a good sign we suggest using the [snapshots](using-snapshots) to save the state of
+As a good sign we suggest using the [snapshots](/developers/snapshot-overview) to save the state of
 the step. Configure the [rebound](/getting-started/rebound) to enable automatic retry
 of messages in case of failures. And the last not least, use the retry.
 

--- a/content/_developers/snapshot-overview.md
+++ b/content/_developers/snapshot-overview.md
@@ -12,9 +12,9 @@ This document provides basic information on [Snapshot](#component-snapshots) fea
 
 ## Component Snapshots
 
-You may have heard of snapshots before, in terms of backup or other data-related topics. Basically, a snapshot is a saved state that you can revert to if needed. It can be an OS snapshot, an application snapshot, and in our case - a [Flow](integration-flow) step snapshot.
+You may have heard of snapshots before, in terms of backup or other data-related topics. Basically, a snapshot is a saved state that you can revert to if needed. It can be an OS snapshot, an application snapshot, and in our case - a [Flow](/getting-started/integration-flow) step snapshot.
 
-Containers that house the steps often get started and stopped, for example, to conserve resources. When a container is stopped, the [Component](integration-component) loses all the data that was in processing. In case this Component has to start again, it will have to request and process the same data all over again.
+Containers that house the steps often get started and stopped, for example, to conserve resources. When a container is stopped, the [Component](/getting-started/integration-component) loses all the data that was in processing. In case this Component has to start again, it will have to request and process the same data all over again.
 
 That's where snapshots come in handy. A snapshot contains information about Component state when it was run last. The next time that Component runs, it will start from the same point it ended the last time. Basically, a snapshot saves a step's last action. This way:
 
@@ -24,7 +24,7 @@ That's where snapshots come in handy. A snapshot contains information about Comp
 
 It is important to understand, that taking snapshots and using them is an asynchronous process. This means that if a Component fails before another snapshot is taken, it will lose all the data between failure and the last snapshot.
 
-Also, an important thing is that there can only be one snapshot per step in a Flow. A snapshot is limited to `5 KB`, so **please refrain from trying to use it as an intermediate database and writing unnecessary data there**.  
+Also, an important thing is that there can only be one snapshot per step in a Flow. A snapshot is limited to `5 KB`, so **please refrain from trying to use it as an intermediate database and writing unnecessary data there**.
 
 ## Use Cases
 

--- a/content/_getting-started/platform-tour.md
+++ b/content/_getting-started/platform-tour.md
@@ -69,7 +69,7 @@ For more information please visite our [Managing Workspaces](/guides/managing-wo
 
 ### Agents
 
-This is the [VPN Agent](vpn-agent) management page **(1)**. Here you can manage your Local Agents **(2)**, and create them **(3)**.
+This is the [VPN Agent](/guides/vpn-agent) management page **(1)**. Here you can manage your Local Agents **(2)**, and create them **(3)**.
 
 {% include img.html max-width="100%" url="/assets/img/getting-started/tour/agents.png" title="Agents" %}
 
@@ -85,7 +85,7 @@ This is the page where you can manage your Workspace **(1)**. This includes chan
 
 {% include img.html max-width="100%" url="/assets/img/getting-started/tour/workspace.png" title="Organize Workspace" %}
 
-For more information please visite our [Managing Workspaces](/guides/managing-workspaces) page.
+For more information please visit our [Managing Workspaces](/guides/managing-workspaces) page.
 
 ## Contract Settings
 

--- a/content/_guides/configuring-help-links.md
+++ b/content/_guides/configuring-help-links.md
@@ -6,7 +6,7 @@ order: 1
 category: integrator-management
 ---
 
-This document explains how to configure [help links](#help-links) for Platform UI and provides [examples](examples).
+This document explains how to configure [help links](#help-links) for Platform UI and provides [examples](#examples).
 
 ## Help Links
 You can put help links on different stages of integration Flow creation:

--- a/content/_guides/credential.md
+++ b/content/_guides/credential.md
@@ -65,6 +65,6 @@ A new credential can be added by pressing the `Add New Credential` button that y
 
 ## Related links
 
-- [Integration flows](integration-flow)
-- [Creating a flow](first-flow)
+- [Integration flows](/getting-started/integration-flow)
+- [Creating a flow](/getting-started/first-flow)
 - [Petstore API]({{site.data.tenant.petStoreDocs}})

--- a/content/_guides/credential.md
+++ b/content/_guides/credential.md
@@ -9,7 +9,7 @@ redirect_from:
   - /getting-started/credential.html
 ---
 
-An [integration flow](integration-flow) runs on behalf of a person or an
+An [integration flow](/getting-started/integration-flow) runs on behalf of a person or an
 organization to synchronize data between multiple applications. Each step
 of an integration flow is accessing a particular application, for example
 through an API, to retrieve, store or update some data. Usually
@@ -35,7 +35,7 @@ component or any other API.
 
 ## Creating a credential for a flow
 
-When [creating a flow](first-flow) an credential must be chosen. You can
+When [creating a flow](/getting-started/first-flow) an credential must be chosen. You can
 either chose an existing one or create a new one. The following screenshot
 demonstrates how the credential is created for the [Petstore API]({{site.data.tenant.petStoreDocs}})
 component.

--- a/content/_guides/mapping-data.md
+++ b/content/_guides/mapping-data.md
@@ -46,7 +46,7 @@ You can add this structure manually using the appropriate function:
 {% include img.html max-width="80%" url="/assets/img/integrator-guide/data-mapper/mapping-webhook.png" title="Mapping: Configure input" %}
 
 We intend to map these values into outgoing fields in the
-[**Petstore component**](/components/petstore/). Let us jump into the integration
+[**Petstore component**](/components/petstore-nodejs/). Let us jump into the integration
 flow design right at the mapping stage.
 
 {% include img.html max-width="80%" url="/assets/img/integrator-guide/data-mapper/mapper-01.png" title="Mapping: Configure input" %}

--- a/content/_guides/using-snapshots.md
+++ b/content/_guides/using-snapshots.md
@@ -11,7 +11,7 @@ This document provides a quick guide on [creating and using Snapshots](#creating
 
 ## Creating and Using a Snapshot
 
-To create a [Snapshot](/getting-started/snapshot-overview.html), you need to emit it from your Component function:
+To create a [Snapshot](/guides/using-snapshots), you need to emit it from your Component function:
 
 `emit('snapshot',snapshot)`
 


### PR DESCRIPTION
Fixing some broken links in the content. Some of the links I could not figure out where they were meant to go. See below a list of links that are still broken:

URL        `/releases/2020-12-17'
Name       `20.51'
Parent URL http://localhost:4000/components/salesforce/index.html, line 224, col 45
Real URL   http://localhost:4000/releases/2020-12-17
Check time 3.947 seconds
Size       4KB
Result     Error: 404 Not Found

URL        `technical-notes#changelog'
Parent URL http://localhost:4000/components/salesphere/index.html, line 129, col 56
Real URL   http://localhost:4000/components/salesphere/technical-notes#changelog
Check time 3.275 seconds
Size       4KB
Result     Error: 404 Not Found

URL        `technical-notes#changelog'
Parent URL http://localhost:4000/components/goto-webinar/index.html, line 129, col 56
Real URL   http://localhost:4000/components/goto-webinar/technical-notes#changelog
Check time 4.252 seconds
Size       4KB
Result     Error: 404 Not Found